### PR TITLE
Feat: Added getMNList RPC call

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -128,6 +128,7 @@ Bitcoin.prototype._initCaches = function() {
   this.summaryCache = LRU(50000);
   this.blockOverviewCache = LRU(144);
   this.transactionDetailedCache = LRU(100000);
+  this.masternodeListCache = LRU(50000);
 
   // caches valid indefinitely
   this.transactionCache = LRU(100000);
@@ -169,6 +170,7 @@ Bitcoin.prototype.getAPIMethods = function() {
     ['getBlockHashesByTimestamp', this, this.getBlockHashesByTimestamp, 2],
     ['getBestBlockHash', this, this.getBestBlockHash, 0],
     ['getSpentInfo', this, this.getSpentInfo, 1],
+    ['getMNList', this, this.getMNList, 1],
     ['getInfo', this, this.getInfo, 0],
     ['syncPercentage', this, this.syncPercentage, 0],
     ['isSynced', this, this.isSynced, 0],
@@ -449,6 +451,7 @@ Bitcoin.prototype._resetCaches = function() {
   this.balanceCache.reset();
   this.summaryCache.reset();
   this.blockOverviewCache.reset();
+  this.masternodeList.reset();
 };
 
 Bitcoin.prototype._tryAllClients = function(func, callback) {
@@ -2088,16 +2091,136 @@ Bitcoin.prototype.govObjectList = function(options, callback) {
 
 Bitcoin.prototype.getMNList = function(callback){
   var self = this;
-  this.client.masternodelist('full', function(err, response){
+  var rawResults= {};
+  var MNList = [];
+  
+  var getRank = function(next){
+    self.client.masternodelist('rank', function(err, response){
+      if(response && response.hasOwnProperty('result')){
+        var result = response.result;
+        rawResults.rank=result;
+      }
+	  next();
+    });
+  };
+  var getProtocol = function(next){
+	  self.client.masternodelist('protocol', function(err, response){
+		  if(response && response.hasOwnProperty('result')){
+			  var result = response.result;
+			  rawResults.protocol=result;
+		  }
+		  next();
+	  });
+  };
+  var getPayee = function(next){
+	  self.client.masternodelist('payee', function(err, response){
+		  if(response && response.hasOwnProperty('result')){
+			  var result = response.result;
+			  rawResults.payee=result;
+		  }
+		  next();
+	  });
+  };
+  var getLastSeen = function(next){
+	  self.client.masternodelist('lastseen', function(err, response){
+		  if(response && response.hasOwnProperty('result')){
+			  var result = response.result;
+			  rawResults.lastseen=result;
+		  }
+		  next();
+	  });
+  };
+  var getActiveSeconds=function(next){
+	  self.client.masternodelist('activeseconds', function(err, response){
+		  if(response && response.hasOwnProperty('result')){
+			  var result = response.result;
+			  rawResults.activeseconds=result;
+		  }
+		  next();
+	  });
+  };
+  var getIP = function(next){
+	  self.client.masternodelist('addr', function(err, response){
+		  if(response && response.hasOwnProperty('result')){
+			  var result = response.result;
+			  rawResults.addr=result;
+		  }
+		  next();
+	  });
+  };
+  var getStatus = function(next){
+	  self.client.masternodelist('status', function(err, response){
+		  if(response && response.hasOwnProperty('result')){
+			  var result = response.result;
+			  rawResults.status=result;
+		  }
+		  next();
+	  });
+  }
+  //DEACTIVATED because of slow response from dashd
+  var getLastPaidBlock = function(next){
+	  self.client.masternodelist('lastpaidblock', function(err, response){
+		  if(response && response.hasOwnProperty('result')){
+			  var result = response.result;
+			  rawResults.lastpaidblock=result;
+		  }
+		  next();
+	  });
+  }
+  //DEACTIVATED because of slow response from dashd
+  var getLastPaidTime = function(next){
+	  self.client.masternodelist('lastpaidtime', function(err, response){
+		  if(response && response.hasOwnProperty('result')){
+			  var result = response.result;
+			  rawResults.lastpaidtime=result;
+		  }
+		  next();
+	  });
+  }
+  var prepareResponse = function(err){
     if(err){
-      return callback(self._wrapRPCError(err));
+	    return callback(err,null);
     }
-    if(response.hasOwnProperty('result')){
-	    callback(response.result);
+    var keys = Object.keys(rawResults);
+    if(
+        keys.indexOf('rank') > -1 &&
+	    keys.indexOf('protocol')> -1 &&
+	    keys.indexOf('payee')> -1 &&
+	    keys.indexOf('lastseen')> -1 &&
+	    keys.indexOf('activeseconds')> -1 &&
+	    keys.indexOf('addr')> -1
+    ){
+        var rankKeys = Object.keys(rawResults['rank']);
+        var rankLength = rankKeys.length;
+        
+        //We get threw all vins by rank 
+        for(var i = 0; i<rankLength; i++){
+          var vin = rankKeys[i];
+          var MN = {
+              vin:vin,
+              status:rawResults['status'][vin],
+              rank:i+1,
+              ip:rawResults['addr'][vin],
+              protocol:rawResults['protocol'][vin],
+              payee:rawResults['payee'][vin],
+              activeseconds:rawResults['activeseconds'][vin]
+            }
+          MNList.push(MN);
+        }
     }else{
-      callback([]);
+          return callback(new Error('Invalid MasternodeList'),null);
     }
-  });
+	  self.masternodeListCache.set('', MNList);
+	  return callback(null, MNList);
+  }
+  var MNListData = self.masternodeListCache.get('');
+  if (MNListData) {
+      return setImmediate(function() {
+	      callback(null, MNListData);
+      });
+  } else {
+	  return async.series([getRank, getProtocol, getPayee, getLastSeen, getActiveSeconds, getIP, getStatus],prepareResponse);
+  }
 };
 
 

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -2086,6 +2086,20 @@ Bitcoin.prototype.govObjectList = function(options, callback) {
   });
 };
 
+Bitcoin.prototype.getMNList = function(callback){
+  var self = this;
+  this.client.masternodelist('full', function(err, response){
+    if(err){
+      return callback(self._wrapRPCError(err));
+    }
+    if(response.hasOwnProperty('result')){
+	    callback(response.result);
+    }else{
+      callback([]);
+    }
+  });
+};
+
 
 /**
  * Retrieves a Governance Object by Hash

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -451,7 +451,7 @@ Bitcoin.prototype._resetCaches = function() {
   this.balanceCache.reset();
   this.summaryCache.reset();
   this.blockOverviewCache.reset();
-  this.masternodeList.reset();
+  this.masternodeListCache.reset();
 };
 
 Bitcoin.prototype._tryAllClients = function(func, callback) {
@@ -2203,7 +2203,8 @@ Bitcoin.prototype.getMNList = function(callback){
               ip:rawResults['addr'][vin],
               protocol:rawResults['protocol'][vin],
               payee:rawResults['payee'][vin],
-              activeseconds:rawResults['activeseconds'][vin]
+              activeseconds:rawResults['activeseconds'][vin],
+              lastseen:rawResults['lastseen'][vin],
             }
           MNList.push(MN);
         }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "async": "^1.3.0",
-    "bitcoind-rpc-dash": "^0.7.1",
+    "bitcoind-rpc-dash": "^0.7.2",
     "bitcore-lib-dash": "^0.13.20",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "async": "^1.3.0",
-    "bitcoind-rpc-dash": "^0.7.2",
+    "bitcoind-rpc-dash": "^1.0.0",
     "bitcore-lib-dash": "^0.13.20",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",

--- a/test/services/bitcoind.unit.js
+++ b/test/services/bitcoind.unit.js
@@ -55,6 +55,7 @@ describe('Bitcoin Service', function() {
       should.exist(bitcoind.balanceCache);
       should.exist(bitcoind.summaryCache);
       should.exist(bitcoind.transactionDetailedCache);
+      should.exist(bitcoind.masternodeListCache);
 
       should.exist(bitcoind.transactionCache);
       should.exist(bitcoind.rawTransactionCache);
@@ -105,7 +106,7 @@ describe('Bitcoin Service', function() {
       var bitcoind = new BitcoinService(baseConfig);
       var methods = bitcoind.getAPIMethods();
       should.exist(methods);
-      methods.length.should.equal(21);
+      methods.length.should.equal(22);
     });
   });
 
@@ -5175,6 +5176,73 @@ describe('Bitcoin Service', function() {
       });
     });
 
+  });
+  
+  describe('#masternodeList', function(){
+    it('will call client masternode list and give result', function(done){
+	    var bitcoind = new BitcoinService(baseConfig);
+	    bitcoind.nodes.push({
+		    client: {
+			    masternodelist: function(type, cb){
+			      switch (type){
+                      case "rank":
+	                      return cb(null, { result:
+		                      { '06c4c53b64019a021e8597c19e40807038cab4cd422ca9241db82aa19887354b-0': 1,
+			                      'b76bafae974b80204e79858eb62aedec41159519c90d23f811cca1eca40f2e4c-1': 2}
+	                      });
+				      case "protocol":
+					      return cb(null, { result:
+						      { '06c4c53b64019a021e8597c19e40807038cab4cd422ca9241db82aa19887354b-0': 70206,
+							      'b76bafae974b80204e79858eb62aedec41159519c90d23f811cca1eca40f2e4c-1': 70206}
+					      });
+                      case "payee":
+	                      return cb(null, { result:
+		                      { '06c4c53b64019a021e8597c19e40807038cab4cd422ca9241db82aa19887354b-0': "Xfpp5BxPfFistPPjTe6FucYmtDVmT1GDG3",
+			                      'b76bafae974b80204e79858eb62aedec41159519c90d23f811cca1eca40f2e4c-1': "Xn16rfdygfViHe2u36jkDUs9NLmUrUsEKa"}
+	                      });
+				      case "lastseen":
+					      return cb(null, { result:
+						      { '06c4c53b64019a021e8597c19e40807038cab4cd422ca9241db82aa19887354b-0': 1502078120,
+							      'b76bafae974b80204e79858eb62aedec41159519c90d23f811cca1eca40f2e4c-1': 1502078203}
+					      });
+				      case "activeseconds":
+					      return cb(null, { result:
+						      { '06c4c53b64019a021e8597c19e40807038cab4cd422ca9241db82aa19887354b-0': 7016289,
+							      'b76bafae974b80204e79858eb62aedec41159519c90d23f811cca1eca40f2e4c-1': 2871829}
+					      });
+				        break;
+				      case "addr":
+					      return cb(null, { result:
+						      { '06c4c53b64019a021e8597c19e40807038cab4cd422ca9241db82aa19887354b-0': "108.61.209.47:9999",
+							      'b76bafae974b80204e79858eb62aedec41159519c90d23f811cca1eca40f2e4c-1': "34.226.228.73:9999"}
+					      });
+				      case "status":
+					      return cb(null, { result:
+						      { '06c4c53b64019a021e8597c19e40807038cab4cd422ca9241db82aa19887354b-0': "ENABLED",
+							      'b76bafae974b80204e79858eb62aedec41159519c90d23f811cca1eca40f2e4c-1': "ENABLED"}
+					      });
+                  }
+                }
+		    }
+	    });
+	    
+	    bitcoind.getMNList(function(err, MNList) {
+		    if (err) {
+			    return done(err);
+		    }
+		    
+		    MNList.length.should.equal(2);
+		    MNList[0].vin.should.equal("06c4c53b64019a021e8597c19e40807038cab4cd422ca9241db82aa19887354b-0");
+		    MNList[0].status.should.equal("ENABLED");
+		    MNList[0].rank.should.equal(1);
+		    MNList[0].ip.should.equal("108.61.209.47:9999");
+		    MNList[0].protocol.should.equal(70206);
+		    MNList[0].payee.should.equal("Xfpp5BxPfFistPPjTe6FucYmtDVmT1GDG3");
+		    MNList[0].activeseconds.should.equal(7016289);
+		    MNList[0].lastseen.should.equal(1502078120);
+		    done();
+	    });
+    });
   });
 
   describe('#generateBlock', function() {


### PR DESCRIPTION
Requirement for https://github.com/dashevo/insight-api-dash/pull/6

Require to bump bitcoind-rpc-dash to 0.7.2 which has the masternodelist RPC call.