### PR TITLE
Feat : Add instantSend support

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -1818,13 +1818,19 @@ Bitcoin.prototype.estimateFee = function(blocks, callback) {
 Bitcoin.prototype.sendTransaction = function(tx, options, callback) {
   var self = this;
   var allowAbsurdFees = false;
+  var isInstantSend = false;
   if (_.isFunction(options) && _.isUndefined(callback)) {
     callback = options;
   } else if (_.isObject(options)) {
-    allowAbsurdFees = options.allowAbsurdFees;
+    if(options.hasOwnProperty('allowAbsurdFees')){
+	    allowAbsurdFees = options.allowAbsurdFees;
+    }
+    if(options.hasOwnProperty('isInstantSend')){
+	    isInstantSend = options.isInstantSend;
+    }
   }
 
-  this.client.sendRawTransaction(tx, allowAbsurdFees, function(err, response) {
+  this.client.sendRawTransaction(tx, allowAbsurdFees, isInstantSend, function(err, response) {
     if (err) {
       return callback(self._wrapRPCError(err));
     }


### PR DESCRIPTION
This P.R add InstantSend support in bitcore-node-dash. 
Requirement for : https://github.com/dashevo/insight-api-dash/pull/5