### PR TITLE
Feature/get spork

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -129,6 +129,7 @@ Bitcoin.prototype._initCaches = function() {
   this.blockOverviewCache = LRU(144);
   this.transactionDetailedCache = LRU(100000);
   this.masternodeListCache = LRU(50000);
+  this.sporksListCache = LRU(50);
 
   // caches valid indefinitely
   this.transactionCache = LRU(100000);
@@ -452,6 +453,7 @@ Bitcoin.prototype._resetCaches = function() {
   this.summaryCache.reset();
   this.blockOverviewCache.reset();
   this.masternodeListCache.reset();
+  this.sporksListCache.reset();
 };
 
 Bitcoin.prototype._tryAllClients = function(func, callback) {
@@ -2093,6 +2095,28 @@ Bitcoin.prototype.govObjectList = function(options, callback) {
     callback(null, result);
 
   });
+};
+
+Bitcoin.prototype.getSpork = function(callback){
+	var self = this;
+	var SporksList = {};
+	self.client.spork('show', function(err, response){
+		if(response && response.hasOwnProperty('result')){
+			var result = {sporks:response.result};
+			var SporksData = self.sporksListCache.get('');
+			if (SporksData) {
+				return setImmediate(function() {
+					callback(null, SporksData);
+				});
+			}else{
+				SporksList=result;
+				self.sporksListCache.set('', SporksList);
+				return callback(null, SporksList);
+			}
+		}else{
+			return callback(new Error('Impossible to get Sporks Data'),null);
+		}
+	});
 };
 
 Bitcoin.prototype.getMNList = function(callback){

--- a/test/services/bitcoind.unit.js
+++ b/test/services/bitcoind.unit.js
@@ -106,7 +106,7 @@ describe('Bitcoin Service', function() {
       var bitcoind = new BitcoinService(baseConfig);
       var methods = bitcoind.getAPIMethods();
       should.exist(methods);
-      methods.length.should.equal(22);
+      methods.length.should.equal(23);
     });
   });
 
@@ -5177,7 +5177,50 @@ describe('Bitcoin Service', function() {
     });
 
   });
-  
+	describe('#sporksList', function(){
+		it('will call client sporks and give result', function(done){
+			var bitcoind = new BitcoinService(baseConfig);
+
+			bitcoind.nodes.push({
+				client: {
+					spork: function(param, callback){
+						if(param==="show"){
+							callback(null,{result:{
+								"SPORK_2_INSTANTSEND_ENABLED":0,
+								"SPORK_3_INSTANTSEND_BLOCK_FILTERING":0,
+								"SPORK_5_INSTANTSEND_MAX_VALUE":2000,
+								"SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT":0,
+								"SPORK_9_SUPERBLOCKS_ENABLED":0,
+								"SPORK_10_MASTERNODE_PAY_UPDATED_NODES":0,
+								"SPORK_12_RECONSIDER_BLOCKS":0,
+								"SPORK_13_OLD_SUPERBLOCK_FLAG":4070908800,
+								"SPORK_14_REQUIRE_SENTINEL_FLAG":4070908800
+							}
+							})
+						}
+					}
+				}
+			});
+			bitcoind.getSpork(function(err, SporkList) {
+				if (err) {
+					return done(err);
+				}
+				SporkList.should.have.property('sporks');
+				var sporks = SporkList.sporks;
+				Object.keys(sporks).length.should.equal(9);
+				sporks['SPORK_2_INSTANTSEND_ENABLED'].should.equal(0);
+				sporks['SPORK_3_INSTANTSEND_BLOCK_FILTERING'].should.equal(0);
+				sporks['SPORK_5_INSTANTSEND_MAX_VALUE'].should.equal(2000);
+				sporks['SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT'].should.equal(0);
+				sporks['SPORK_9_SUPERBLOCKS_ENABLED'].should.equal(0);
+				sporks['SPORK_10_MASTERNODE_PAY_UPDATED_NODES'].should.equal(0);
+				sporks['SPORK_12_RECONSIDER_BLOCKS'].should.equal(0);
+				sporks['SPORK_13_OLD_SUPERBLOCK_FLAG'].should.equal(4070908800);
+				sporks['SPORK_14_REQUIRE_SENTINEL_FLAG'].should.equal(4070908800);
+				done();
+			});
+		});
+	});
   describe('#masternodeList', function(){
     it('will call client masternode list and give result', function(done){
 	    var bitcoind = new BitcoinService(baseConfig);


### PR DESCRIPTION
In order for a developer/end user to verify all conditions for an instantSend transaction, the spork value "SPORK_5_INSTANTSEND_MAX_VALUE" should be retrievable. 
In order to do so, Insight-API will first require spork to be retrieved from bitcore-node-dash. 

This P.R aim to implement getSpork (RPC `spork show`).
Every time one will request a SPORK list, it will be stored in a LRU cache for a duration of one block.

Start to resolve https://github.com/dashevo/insight-api-dash/issues/7