### PR TITLE
fix download script

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -5,8 +5,8 @@ set -e
 root_dir="${HOME}/.bitcore"
 platform=`uname -a | awk '{print tolower($1)}'`
 arch=`uname -m`
-version="0.12.1"
-url="https://bamboo.dash.org/browse/DASHL-REL/latestSuccessful/artifact/JOB1/gitian-linux-dash-dist"
+version="0.12.2"
+url="https://bamboo.dash.org/browse/DASHL-REL-13/artifact/JOB1/gitian-linux-dash-dist"
 
 if [ "${platform}" == "linux" ]; then
     if [ "${arch}" == "x86_64" ]; then


### PR DESCRIPTION
This commit changes permissions for the download script to +x (see https://github.com/dashevo/bitcore-node-dash/issues/12) and also updates the download location/version.